### PR TITLE
Small Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 0.9.6 - 12.03.2023
+
+- other changes
+  - use `self-drive-car` type for car sharing response types
+  - fix on-demand bus mode that was matching also the normal bus routes
+  - add types to `Location` object so we can differentiate between Stop, POI, TopographicPlace and Address
+  - LIR name lookup requests can also filter by type, i.e. `Stop`
+  - adjust BBOX for the trips to include also the leg polylines
+
 ## 0.9.5 - 19.02.2023
 - fix for broken taxi / booking data - see [OJP demo app extension #87](https://github.com/openTdataCH/ojp-demo-app-src/issues/87), [#12](https://github.com/openTdataCH/ojp-js/pull/12)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ojp-sdk",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "OJP (Open Journey Planner) Javascript SDK",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/journey/public-transport-mode.ts
+++ b/src/journey/public-transport-mode.ts
@@ -27,7 +27,8 @@ export class PublicTransportMode {
     const publicTransportMode = new PublicTransportMode(ptMode, name, shortName)
 
     const busSubmode = XPathOJP.queryText('ojp:Mode/siri:BusSubmode', serviceNode)
-    publicTransportMode.isDemandMode = busSubmode !== null
+    // publicTransportMode.isDemandMode = busSubmode !== null;
+    publicTransportMode.isDemandMode = (busSubmode === 'demandAndResponseBus' || busSubmode === 'unknown');
 
     return publicTransportMode
   }

--- a/src/location/location.ts
+++ b/src/location/location.ts
@@ -10,6 +10,9 @@ interface NearbyLocation {
   location: Location
 }
 
+// TODO - long term: subclass from Location?
+export type LocationType = 'stop' | 'address' | 'poi' | 'topographicPlace'
+
 export class Location {
   public address: Address | null
   public stopPointRef: string | null
@@ -235,5 +238,25 @@ export class Location {
     });
 
     return closestLocation;
+  }
+
+  public getLocationType(): LocationType | null {
+    if (this.stopPlace) {
+      return 'stop';
+    }
+
+    if (this.poi) {
+      return 'poi';
+    }
+
+    if (this.address) {
+      return 'address';
+    }
+
+    if (this.topographicPlace) {
+      return 'topographicPlace';
+    }
+
+    return null
   }
 }

--- a/src/request/location-information/location-information-request.ts
+++ b/src/request/location-information/location-information-request.ts
@@ -15,9 +15,13 @@ export class LocationInformationRequest extends OJPBaseRequest {
     this.requestParams = requestParams;
   }
 
-  public static initWithLocationName(stageConfig: StageConfig, locationName: string): LocationInformationRequest {
+  public static initWithLocationName(stageConfig: StageConfig, locationName: string, geoRestrictionType: GeoRestrictionType | null = null): LocationInformationRequest {
     const requestParams = <LocationInformationRequestParams>{
       locationName: locationName
+    }
+
+    if (geoRestrictionType !== null) {
+      requestParams.geoRestrictionType = geoRestrictionType;
     }
 
     const locationInformationRequest = new LocationInformationRequest(stageConfig, requestParams);
@@ -167,14 +171,18 @@ export class LocationInformationRequest extends OJPBaseRequest {
   }
 
   private computeRestrictionType(): string | null {
-      if (this.requestParams.geoRestrictionType === 'poi_all') {
-        return 'poi'
-      }
+    if (this.requestParams.geoRestrictionType === 'stop') {
+      return 'stop';
+    }
 
-      if (this.requestParams.geoRestrictionType === 'poi_amenity') {
-        return 'poi'
-      }
+    if (this.requestParams.geoRestrictionType === 'poi_all') {
+      return 'poi'
+    }
 
-      return this.requestParams.geoRestrictionType;
+    if (this.requestParams.geoRestrictionType === 'poi_amenity') {
+      return 'poi'
+    }
+
+    return this.requestParams.geoRestrictionType;
   }
 }

--- a/src/trip/leg/trip-continous-leg.ts
+++ b/src/trip/leg/trip-continous-leg.ts
@@ -78,7 +78,7 @@ export class TripContinousLeg extends TripLeg {
     }
 
     if (legModeS === 'self-drive-car') {
-      return 'car_self_driving'
+      return 'self-drive-car'
     }
 
     if (legModeS === 'cycle') {
@@ -93,7 +93,7 @@ export class TripContinousLeg extends TripLeg {
   }
 
   public isDriveCarLeg(): boolean {
-    return this.legTransportMode === 'car_self_driving';
+    return this.legTransportMode === 'self-drive-car';
   }
 
   public isSharedMobility(): boolean {

--- a/src/trip/trip.ts
+++ b/src/trip/trip.ts
@@ -9,6 +9,7 @@ import { TripContinousLeg } from './leg/trip-continous-leg'
 import { Duration } from '../shared/duration'
 import { Location } from '../location/location';
 import { GeoPositionBBOX } from '../location/geoposition-bbox'
+import { GeoPosition } from '../location/geoposition'
 import { IndividualTransportMode } from '../types/individual-mode.types'
 
 export class Trip {
@@ -208,6 +209,19 @@ export class Trip {
     if (toGeoPosition) {
       bbox.extend(toGeoPosition);
     }
+
+    this.legs.forEach(leg => {
+      const features = leg.computeGeoJSONFeatures();
+      features.forEach(feature => {
+        const featureBBOX = feature.bbox ?? null;
+        if (featureBBOX === null) {
+          return;
+        }
+
+        bbox.extend(new GeoPosition(featureBBOX[0], featureBBOX[1]));
+        bbox.extend(new GeoPosition(featureBBOX[2], featureBBOX[3]));
+      });
+    });
 
     return bbox;
   }

--- a/src/types/individual-mode.types.ts
+++ b/src/types/individual-mode.types.ts
@@ -1,1 +1,1 @@
-export type IndividualTransportMode = 'public_transport' | 'walk' | 'cycle' | 'escooter_rental' | 'car_sharing' | 'car_self_driving' | 'bicycle_rental' | 'charging_station' | 'taxi'
+export type IndividualTransportMode = 'public_transport' | 'walk' | 'cycle' | 'escooter_rental' | 'car_sharing' | 'self-drive-car' | 'bicycle_rental' | 'charging_station' | 'taxi'


### PR DESCRIPTION
- use `self-drive-car` type for car sharing response types
- fix on-demand bus mode that was matching also the normal bus routes
- add types to `Location` object so we can differentiate between Stop, POI, TopographicPlace and Address
- LIR name lookup requests can also filter by type, i.e. `Stop`
- adjust BBOX for the trips to include also the leg polylines