### PR TITLE
Improve TripRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # CHANGELOG
 
 ## 0.9.6 - 12.03.2023
-
+- improve TripRequest
+  - removed `ojp:NumberOfResults`, keep it only for TEST LA
+  - `IndividualTransportOptions` is used only for monomodal, walk | cycle (own bicyicle) modes - with different max duration params
+  - use `ItModesToCover` for walk | self drive | cycle modes
+  - use OJP `Extension` for bicycle_rental | car_sharing | escooter_rental modes
 - other changes
   - use `self-drive-car` type for car sharing response types
   - fix on-demand bus mode that was matching also the normal bus routes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # CHANGELOG
 
 ## 0.9.6 - 12.03.2023
-- improve TripRequest
+- improve TripRequest - see [#14](https://github.com/openTdataCH/ojp-js/pull/14)
   - removed `ojp:NumberOfResults`, keep it only for TEST LA
   - `IndividualTransportOptions` is used only for monomodal, walk | cycle (own bicyicle) modes - with different max duration params
   - use `ItModesToCover` for walk | self drive | cycle modes
   - use OJP `Extension` for bicycle_rental | car_sharing | escooter_rental modes
-- other changes
+- other changes - see [#13](https://github.com/openTdataCH/ojp-js/pull/13)
   - use `self-drive-car` type for car sharing response types
   - fix on-demand bus mode that was matching also the normal bus routes
   - add types to `Location` object so we can differentiate between Stop, POI, TopographicPlace and Address

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Include the `ojp-sdk` package in the `./package.json` dependencies of your proje
 
 ```
   "dependencies": {
-    "ojp-sdk": "0.9.5"
+    "ojp-sdk": "0.9.6"
   }
 ```
 

--- a/src/request/trips-request/trips-request.ts
+++ b/src/request/trips-request/trips-request.ts
@@ -87,10 +87,20 @@ export class TripRequest extends OJPBaseRequest {
 
         // https://github.com/openTdataCH/ojp-demo-app-src/issues/64
         // Allow maxduration for more than 40m for walking / cycle monomodal routes
-        if (isMonomodal && (transportMode === 'walk' || transportMode === 'cycle')) {
-          const transportModeOptionsNode = endPointNode.ele('ojp:IndividualTransportOptions');
-          transportModeOptionsNode.ele('ojp:Mode', transportMode);
-          transportModeOptionsNode.ele('ojp:MaxDuration', 'PT3000M');
+        
+        if (isMonomodal) {
+          const modesWithOptions: IndividualTransportMode[] = ['walk', 'cycle'];
+          if (modesWithOptions.indexOf(transportMode) !== -1) {
+            const transportModeOptionsNode = endPointNode.ele('ojp:IndividualTransportOptions');
+            transportModeOptionsNode.ele('ojp:Mode', transportMode);
+            
+            if (transportMode === 'walk') {
+              transportModeOptionsNode.ele('ojp:MaxDuration', 'PT3000M');
+            }
+            if (transportMode === 'cycle') {
+              transportModeOptionsNode.ele('ojp:MaxDuration', 'PT600M');
+            }
+          }
         }
       }
     });
@@ -98,7 +108,9 @@ export class TripRequest extends OJPBaseRequest {
     const paramsNode = tripRequestNode.ele('ojp:Params');
 
     const numberOfResults = this.computeNumberOfResultsParam();
-    paramsNode.ele('ojp:NumberOfResults', numberOfResults);
+    if (numberOfResults !== null) {
+      paramsNode.ele('ojp:NumberOfResults', numberOfResults);
+    }
 
     paramsNode.ele('ojp:IncludeTrackSections', true)
     paramsNode.ele('ojp:IncludeLegProjection', true)
@@ -106,16 +118,9 @@ export class TripRequest extends OJPBaseRequest {
     paramsNode.ele('ojp:IncludeIntermediateStops', true)
 
     if (isMonomodal) {
-      if (transportMode === 'walk') {
-        paramsNode.ele('ojp:ItModesToCover', 'walk');
-      }
-
-      if (transportMode === 'car_self_driving') {
-        paramsNode.ele('ojp:ItModesToCover', 'self-drive-car');
-      }
-
-      if (transportMode === 'cycle') {
-        paramsNode.ele('ojp:ItModesToCover', 'cycle');
+      const standardModes: IndividualTransportMode[] = ['walk', 'self-drive-car', 'cycle'];
+      if (standardModes.indexOf(transportMode) !== -1) {
+        paramsNode.ele('ojp:ItModesToCover', transportMode);
       } 
 
       const sharingModes: IndividualTransportMode[] = ['bicycle_rental', 'car_sharing', 'escooter_rental'];
@@ -153,19 +158,11 @@ export class TripRequest extends OJPBaseRequest {
     }
   }
 
-  private computeNumberOfResultsParam(): number {
+  private computeNumberOfResultsParam(): number | null {
     if (this.stageConfig.key === 'TEST LA') {
       return 1;
     }
-
-    if (this.requestParams.modeType === 'monomodal') {
-      const customModes: IndividualTransportMode[] = ['walk', 'cycle', 'car_self_driving', 'bicycle_rental', 'escooter_rental', 'car_sharing'];
-      const isCustomMode = customModes.indexOf(this.requestParams.transportMode) !== -1;
-      if (isCustomMode) {
-        return 0;
-      }
-    }
-
-    return 5;
+    
+    return null;
   }
 }

--- a/src/request/trips-request/trips-request.ts
+++ b/src/request/trips-request/trips-request.ts
@@ -18,7 +18,7 @@ export class TripRequest extends OJPBaseRequest {
     this.buildTripRequestNode();
     const bodyXML_s = this.serviceRequestNode.end();
     super.fetchOJPResponse(bodyXML_s, (responseText, errorData) => {
-      const tripsResponse = TripsResponse.initWithXML(responseText, this.requestParams.transportMode);
+      const tripsResponse = TripsResponse.initWithXML(responseText, this.requestParams.modeType, this.requestParams.transportMode);
       if (errorData === null && !tripsResponse.hasValidResponse) {
         errorData = {
           error: 'ParseTripsXMLError',

--- a/src/trip/trip.ts
+++ b/src/trip/trip.ts
@@ -23,7 +23,7 @@ export class Trip {
     this.stats = tripStats
   }
 
-  public static initFromTripResultNode(tripResultNode: Node, transportMode: IndividualTransportMode) {
+  public static initFromTripResultNode(tripResultNode: Node) {
     const tripId = XPathOJP.queryText('ojp:Trip/ojp:TripId', tripResultNode)
     if (tripId === null) {
       return null;
@@ -74,33 +74,6 @@ export class Trip {
 
       legs.push(tripLeg);
     })
-
-    if (transportMode === 'walk') {
-      const firstNonWalkingLeg = legs.find(leg => {
-        return leg.legType !== 'ContinousLeg'
-      })
-
-      if (firstNonWalkingLeg) {
-        return null
-      }
-    }
-
-    if (transportMode === 'car_self_driving' || transportMode === 'car_sharing') {
-       // TripRequest response returns <ojp:IndividualMode>self-drive-car</ojp:IndividualMode> also for car_sharing
-      const hasLegWithCarMode = Trip.hasLegWithTransportMode(legs, 'car_self_driving');
-      if (!hasLegWithCarMode) {
-        return null;
-      }
-    }
-
-    const customTransportModes: IndividualTransportMode[] = ['cycle', 'bicycle_rental', 'escooter_rental'];
-    if (customTransportModes.indexOf(transportMode) !== -1) {
-      // TripRequest response returns <ojp:IndividualMode>cycle</ojp:IndividualMode> for cycle (indvidual and sharing), escooters (sharing)
-      const hasLegWithTransportMode = Trip.hasLegWithTransportMode(legs, 'cycle');
-      if (hasLegWithTransportMode === false) {
-        return null;
-      }
-    }
 
     const trip = new Trip(tripId, legs, tripStats);
 

--- a/src/trips/trips-response.ts
+++ b/src/trips/trips-response.ts
@@ -2,6 +2,8 @@ import { Location } from '../location/location'
 import { Trip } from '../trip/trip'
 import { XPathOJP } from '../helpers/xpath-ojp'
 import { IndividualTransportMode } from '../types/individual-mode.types'
+import { TripModeType } from '../types/trip-mode-type'
+import { TripContinousLeg } from '../trip/leg/trip-continous-leg'
 
 export class TripsResponse {
   public hasValidResponse: boolean
@@ -16,14 +18,14 @@ export class TripsResponse {
     this.trips = trips
   }
 
-  public static initWithXML(responseXMLText: string, transportMode: IndividualTransportMode): TripsResponse {
+  public static initWithXML(responseXMLText: string, tripModeType: TripModeType, transportMode: IndividualTransportMode): TripsResponse {
     const responseXML = new DOMParser().parseFromString(responseXMLText, 'application/xml');
 
     const statusText = XPathOJP.queryText('//siri:OJPResponse/siri:ServiceDelivery/siri:Status', responseXML)
     const serviceStatus = statusText === 'true'
 
     const contextLocations = TripsResponse.parseContextLocations(responseXML);
-    const trips = TripsResponse.parseTrips(responseXML, contextLocations, transportMode);
+    const trips = TripsResponse.parseTrips(responseXML, contextLocations, tripModeType, transportMode);
 
     const tripResponse = new TripsResponse(serviceStatus, responseXMLText, contextLocations, trips)
 
@@ -42,8 +44,13 @@ export class TripsResponse {
     return locations;
   }
 
-  private static parseTrips(responseXML: Document, contextLocations: Location[], transportMode: IndividualTransportMode): Trip[] {
-    let trips: Trip[] = [];
+  private static parseTrips(
+    responseXML: Document, 
+    contextLocations: Location[], 
+    tripModeType: TripModeType, 
+    transportMode: IndividualTransportMode
+  ): Trip[] {
+    const trips: Trip[] = [];
 
     const mapContextLocations: Record<string, Location> = {}
     contextLocations.forEach(location => {
@@ -55,7 +62,7 @@ export class TripsResponse {
 
     const tripResultNodes = XPathOJP.queryNodes('//ojp:TripResult', responseXML);
     tripResultNodes.forEach(tripResult => {
-      const trip = Trip.initFromTripResultNode(tripResult as Node, transportMode);
+      const trip = Trip.initFromTripResultNode(tripResult as Node);
       if (trip) {
         trip.legs.forEach(leg => {
           leg.patchLocations(mapContextLocations)
@@ -64,6 +71,34 @@ export class TripsResponse {
       }
     });
 
+    TripsResponse.sortTrips(trips, tripModeType, transportMode)
+
     return trips
+  }
+
+  private static sortTrips(trips: Trip[], tripModeType: TripModeType, transportMode: IndividualTransportMode) {
+    if (tripModeType !== 'monomodal') {
+      return trips;
+    }
+
+    // Push first the monomodal trip with one leg matching the transport mode
+    const monomodalTrip = trips.find(trip => {
+      if (trip.legs.length !== 1) {
+        return false;
+      }
+
+      if (trip.legs[0].legType !== 'ContinousLeg') {
+        return false;
+      }
+
+      const continousLeg = trip.legs[0] as TripContinousLeg;
+      return continousLeg.legTransportMode === transportMode;
+    }) ?? null;
+
+    if (monomodalTrip) {
+      const tripIdx = trips.indexOf(monomodalTrip);
+      trips.splice(tripIdx, 1);
+      trips.unshift(monomodalTrip);
+    }
   }
 }


### PR DESCRIPTION
  - removed `ojp:NumberOfResults`, keep it only for TEST LA
  - `IndividualTransportOptions` is used only for monomodal, walk | cycle (own bicyicle) modes - with different max duration params
  - use `ItModesToCover` for walk | self drive | cycle modes
  - use OJP `Extension` for bicycle_rental | car_sharing | escooter_rental modes