### PR TITLE
Add Plus functionality to duration.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.9.8 - 29.03.2023
+- add plus functionality to duration 
+
 ## 0.9.7 - 12.03.2023
 - adds `Location` Probability and OriginSystem - see [#15](https://github.com/openTdataCH/ojp-js/pull/15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.9.8 - 02.04.2023
 - use `cross-fetch` and `xmldom` to enable usage also from command line - see [#17](https://github.com/openTdataCH/ojp-js/pull/17)
   - use `ES6` for both target and module 
-- add plus functionality to duration
+- add plus functionality to duration - see [#16](https://github.com/openTdataCH/ojp-js/pull/16)
 
 ## 0.9.7 - 12.03.2023
 - adds `Location` Probability and OriginSystem - see [#15](https://github.com/openTdataCH/ojp-js/pull/15)

--- a/src/shared/duration.ts
+++ b/src/shared/duration.ts
@@ -59,4 +59,8 @@ export class Duration {
 
     return durationParts.join('')
   }
+
+  public plus(otherDuration: Duration): Duration {
+    return Duration.initFromTotalMinutes(this.totalMinutes + otherDuration.totalMinutes)
+  }
 }


### PR DESCRIPTION
This is needed to calculate a combined duration. The duration is not exported for itselfe, therefore this function is mandatory.
I have no clue how it works with new version iterations and releases.