### PR TITLE
OJP.TripRequest changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 0.9.14 - 23.05.2023
-- `OJP.TripRequest` changes
+- `OJP.TripRequest` changes - see [PR #26](https://github.com/openTdataCH/ojp-js/pull/26)
   - restore `ojp:DepArrTime`
   - allow toggling of the `<ojp:IncludeLegProjection>` param
   - allow usage of either `ojp:NumberOfResultsAfter` or `ojp:NumberOfResults` param

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.9.14 - 23.05.2023
+- `OJP.TripRequest` changes
+  - restore `ojp:DepArrTime`
+  - allow toggling of the `<ojp:IncludeLegProjection>` param
+
 ## 0.9.13 - 14.05.2023
 - use strings for `StageConfig.key`, dont force the consumer to use only predefined OJP stages - see [#24](https://github.com/openTdataCH/ojp-js/pull/24)
 - adds support for taxi mode in `OJP.TripRequest` - see [#87](https://github.com/openTdataCH/ojp-demo-app-src/issues/87), see PR [#25](https://github.com/openTdataCH/ojp-js/pull/25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - `OJP.TripRequest` changes
   - restore `ojp:DepArrTime`
   - allow toggling of the `<ojp:IncludeLegProjection>` param
+  - allow usage of either `ojp:NumberOfResultsAfter` or `ojp:NumberOfResults` param
 
 ## 0.9.13 - 14.05.2023
 - use strings for `StageConfig.key`, dont force the consumer to use only predefined OJP stages - see [#24](https://github.com/openTdataCH/ojp-js/pull/24)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The OJP Javascript SDK is the client used for communication with [OJP APIs](http
 
 ```
   "dependencies": {
-    "ojp-sdk": "0.9.13"
+    "ojp-sdk": "0.9.14"
   }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ojp-sdk",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "OJP (Open Journey Planner) Javascript SDK",
   "main": "lib/index.js",
   "type": "module",

--- a/src/request/journey-request/journey-request-params.ts
+++ b/src/request/journey-request/journey-request-params.ts
@@ -7,6 +7,7 @@ export class JourneyRequestParams {
   tripModeTypes: TripModeType[]
   transportModes: IndividualTransportMode[]
   departureDate: Date
+  includeLegProjection: boolean
 
   constructor(tripLocations: TripLocationPoint[], tripModeTypes: TripModeType[], transportModes: IndividualTransportMode[], departureDate: Date) {
 
@@ -14,6 +15,7 @@ export class JourneyRequestParams {
     this.tripModeTypes = tripModeTypes
     this.transportModes = transportModes
     this.departureDate = departureDate
+    this.includeLegProjection = true
   }
 
   public static initWithLocationsAndDate(

--- a/src/request/journey-request/journey-request.ts
+++ b/src/request/journey-request/journey-request.ts
@@ -37,6 +37,7 @@ export class JourneyRequest extends OJPBaseRequest {
       return
     }
 
+    tripRequestParams.includeLegProjection = this.requestParams.includeLegProjection
     tripRequestParams.modeType = this.requestParams.tripModeTypes[idx];
     tripRequestParams.transportMode = this.requestParams.transportModes[idx];
 

--- a/src/request/trips-request/trips-request-params.ts
+++ b/src/request/trips-request/trips-request-params.ts
@@ -8,6 +8,7 @@ export class TripsRequestParams {
   departureDate: Date
   modeType: TripModeType
   transportMode: IndividualTransportMode
+  includeLegProjection: boolean
 
   constructor(fromTripLocation: TripLocationPoint, toTripLocation: TripLocationPoint, departureDate: Date) {
     this.fromTripLocation = fromTripLocation
@@ -16,6 +17,7 @@ export class TripsRequestParams {
     
     this.modeType = 'monomodal'
     this.transportMode = 'public_transport'
+    this.includeLegProjection = true
   }
 
   public static initWithLocationsAndDate(

--- a/src/request/trips-request/trips-request-params.ts
+++ b/src/request/trips-request/trips-request-params.ts
@@ -9,6 +9,7 @@ export class TripsRequestParams {
   modeType: TripModeType
   transportMode: IndividualTransportMode
   includeLegProjection: boolean
+  useNumberOfResultsAfter: boolean
 
   constructor(fromTripLocation: TripLocationPoint, toTripLocation: TripLocationPoint, departureDate: Date) {
     this.fromTripLocation = fromTripLocation
@@ -17,7 +18,9 @@ export class TripsRequestParams {
     
     this.modeType = 'monomodal'
     this.transportMode = 'public_transport'
+
     this.includeLegProjection = true
+    this.useNumberOfResultsAfter = false
   }
 
   public static initWithLocationsAndDate(

--- a/src/request/trips-request/trips-request.ts
+++ b/src/request/trips-request/trips-request.ts
@@ -139,7 +139,7 @@ export class TripRequest extends OJPBaseRequest {
     }
 
     paramsNode.ele('ojp:IncludeTrackSections', true)
-    paramsNode.ele('ojp:IncludeLegProjection', true)
+    paramsNode.ele('ojp:IncludeLegProjection', this.requestParams.includeLegProjection)
     paramsNode.ele('ojp:IncludeTurnDescription', true)
     paramsNode.ele('ojp:IncludeIntermediateStops', true)
 

--- a/src/request/trips-request/trips-request.ts
+++ b/src/request/trips-request/trips-request.ts
@@ -137,7 +137,8 @@ export class TripRequest extends OJPBaseRequest {
 
     const numberOfResults = this.computeNumberOfResultsParam();
     if (numberOfResults !== null) {
-      paramsNode.ele('ojp:NumberOfResults', numberOfResults);
+      const nodeName = this.requestParams.useNumberOfResultsAfter ? 'ojp:NumberOfResultsAfter' : 'ojp:NumberOfResults';
+      paramsNode.ele(nodeName, numberOfResults);
     }
 
     paramsNode.ele('ojp:IncludeTrackSections', true)

--- a/src/request/trips-request/trips-request.ts
+++ b/src/request/trips-request/trips-request.ts
@@ -81,15 +81,17 @@ export class TripRequest extends OJPBaseRequest {
         }
       }
 
+      if (isFrom) {
+        const dateF = this.requestParams.departureDate.toISOString();
+        endPointNode.ele('ojp:DepArrTime', dateF);  
+      }
+
       if (isMonomodal) {
         if (isFrom) {
           // https://github.com/openTdataCH/ojp-demo-app-src/issues/64
           // Allow maxduration for more than 40m for walking / cycle monomodal routes
           const modesWithOptions: IndividualTransportMode[] = ['walk', 'cycle'];
           if (modesWithOptions.indexOf(transportMode) !== -1) {
-            const dateF = this.requestParams.departureDate.toISOString();
-            endPointNode.ele('ojp:DepArrTime', dateF);  
-
             const transportModeOptionsNode = endPointNode.ele('ojp:IndividualTransportOptions');
             transportModeOptionsNode.ele('ojp:Mode', transportMode);
             


### PR DESCRIPTION
- `OJP.TripRequest` changes
  - restore `ojp:DepArrTime`
  - allow toggling of the `<ojp:IncludeLegProjection>` param
  - allow usage of either `ojp:NumberOfResultsAfter` or `ojp:NumberOfResults` param