### PR TITLE
Small changes - v0.9.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.9.15 - 02.07.2023
+- pretty print the XML payload in the OJP APIs calls
+- `NumberOfResultsAfter` is now default in the `OJP.TripRequest` calls
+- use `PrivateModeFilter` for the OJP APIs calls
+- add helpers for reuse of the `OJP.StopEventRequest` calls
+
 ## 0.9.14 - 23.05.2023
 - `OJP.TripRequest` changes - see [PR #26](https://github.com/openTdataCH/ojp-js/pull/26)
   - restore `ojp:DepArrTime`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 0.9.15 - 02.07.2023
+- [PR #27](https://github.com/openTdataCH/ojp-js/pull/27)
 - pretty print the XML payload in the OJP APIs calls
 - `NumberOfResultsAfter` is now default in the `OJP.TripRequest` calls
 - use `PrivateModeFilter` for the OJP APIs calls

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The OJP Javascript SDK is the client used for communication with [OJP APIs](http
 
 ```
   "dependencies": {
-    "ojp-sdk": "0.9.14"
+    "ojp-sdk": "0.9.15"
   }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ojp-sdk",
-  "version": "0.9.14",
+  "version": "0.9.15",
   "description": "OJP (Open Journey Planner) Javascript SDK",
   "main": "lib/index.js",
   "type": "module",

--- a/src/request/journey-request/journey-request-params.ts
+++ b/src/request/journey-request/journey-request-params.ts
@@ -8,6 +8,8 @@ export class JourneyRequestParams {
   transportModes: IndividualTransportMode[]
   departureDate: Date
   includeLegProjection: boolean
+  useNumberOfResultsAfter: boolean
+
 
   constructor(tripLocations: TripLocationPoint[], tripModeTypes: TripModeType[], transportModes: IndividualTransportMode[], departureDate: Date) {
 
@@ -16,6 +18,7 @@ export class JourneyRequestParams {
     this.transportModes = transportModes
     this.departureDate = departureDate
     this.includeLegProjection = true
+    this.useNumberOfResultsAfter = true
   }
 
   public static initWithLocationsAndDate(

--- a/src/request/journey-request/journey-request.ts
+++ b/src/request/journey-request/journey-request.ts
@@ -38,6 +38,7 @@ export class JourneyRequest extends OJPBaseRequest {
     }
 
     tripRequestParams.includeLegProjection = this.requestParams.includeLegProjection
+    tripRequestParams.useNumberOfResultsAfter = this.requestParams.useNumberOfResultsAfter
     tripRequestParams.modeType = this.requestParams.tripModeTypes[idx];
     tripRequestParams.transportMode = this.requestParams.transportModes[idx];
 

--- a/src/request/location-information/location-information-request.ts
+++ b/src/request/location-information/location-information-request.ts
@@ -63,7 +63,9 @@ export class LocationInformationRequest extends OJPBaseRequest {
 
   public fetchResponse(): Promise<Location[]> {
     this.buildRequestNode();
-    const bodyXML_s = this.serviceRequestNode.end();
+    const bodyXML_s = this.serviceRequestNode.end({
+      pretty: true
+    });
 
     const loadingPromise = new Promise<Location[]>((resolve, reject) => {
       super.fetchOJPResponse(bodyXML_s, (responseText, errorData) => {

--- a/src/request/location-information/location-information-request.ts
+++ b/src/request/location-information/location-information-request.ts
@@ -170,6 +170,9 @@ export class LocationInformationRequest extends OJPBaseRequest {
         })
       }
     }
+
+    const extensionsNode = requestNode.ele('Extensions');
+    extensionsNode.ele('ParamsExtension').ele('PrivateModeFilter').ele('Exclude', 'false');
   }
 
   private computeRestrictionType(): string | null {

--- a/src/request/stop-event-request/stop-event-request-params.ts
+++ b/src/request/stop-event-request/stop-event-request-params.ts
@@ -50,6 +50,9 @@ export class StopEventRequestParams {
         requestParamsNode.ele('ojp:IncludeOnwardCalls', this.includeOnwardCalls);
         requestParamsNode.ele('ojp:IncludeRealtimeData', this.includeRealtimeData);
 
+        const extensionsNode = requestNode.ele('Extensions');
+        extensionsNode.ele('ParamsExtension').ele('PrivateModeFilter').ele('Exclude', 'false');
+
         const bodyXML_s = contextEl.end({
             pretty: true
         });

--- a/src/request/stop-event-request/stop-event-request-params.ts
+++ b/src/request/stop-event-request/stop-event-request-params.ts
@@ -50,7 +50,9 @@ export class StopEventRequestParams {
         requestParamsNode.ele('ojp:IncludeOnwardCalls', this.includeOnwardCalls);
         requestParamsNode.ele('ojp:IncludeRealtimeData', this.includeRealtimeData);
 
-        const bodyXML_s = contextEl.end();
+        const bodyXML_s = contextEl.end({
+            pretty: true
+        });
 
         return bodyXML_s;
     }

--- a/src/request/stop-event-request/stop-event-request.ts
+++ b/src/request/stop-event-request/stop-event-request.ts
@@ -28,7 +28,7 @@ export class StopEventRequest extends OJPBaseRequest {
 
         const loadingPromise = new Promise<StopEvent[]>((resolve, reject) => {
             super.fetchOJPResponse(bodyXML_s, (responseText, errorData) => {
-                const stopEvents = this.handleResponseData(responseText, errorData);
+                const stopEvents = StopEventRequest.handleResponseData(responseText, errorData);
                 resolve(stopEvents);
             });
         });
@@ -36,7 +36,7 @@ export class StopEventRequest extends OJPBaseRequest {
         return loadingPromise;
     }
 
-    private handleResponseData(responseText: string, error: RequestErrorData | null): StopEvent[] {
+    public static handleResponseData(responseText: string, error: RequestErrorData | null): StopEvent[] {
         const stopEvents: StopEvent[] = [];
 
         if (error !== null) {
@@ -47,7 +47,7 @@ export class StopEventRequest extends OJPBaseRequest {
 
         const responseXML = new DOMParser().parseFromString(responseText, 'application/xml');
 
-        const mapContextLocations = this.parseMapContextLocations(responseXML);
+        const mapContextLocations = StopEventRequest.parseMapContextLocations(responseXML);
 
         const nodes = XPathOJP.queryNodes('//ojp:OJPStopEventDelivery/ojp:StopEventResult/ojp:StopEvent', responseXML);
         nodes.forEach(node => {
@@ -61,7 +61,7 @@ export class StopEventRequest extends OJPBaseRequest {
         return stopEvents;
     }
 
-    private parseMapContextLocations(responseXML: Document): Record<string, Location> {
+    private static parseMapContextLocations(responseXML: Document): Record<string, Location> {
         const mapContextLocations: Record<string, Location> = {};
 
         const locationNodes = XPathOJP.queryNodes('//ojp:OJPStopEventDelivery/ojp:StopEventResponseContext/ojp:Places/ojp:Location', responseXML);

--- a/src/request/stop-event-request/stop-event-request.ts
+++ b/src/request/stop-event-request/stop-event-request.ts
@@ -61,6 +61,11 @@ export class StopEventRequest extends OJPBaseRequest {
         return stopEvents;
     }
 
+    public computeRequestXmlString(): string {
+        const bodyXML_s = this.requestParams.buildRequestXML(this.serviceRequestNode);
+        return bodyXML_s;
+    }
+
     private static parseMapContextLocations(responseXML: Document): Record<string, Location> {
         const mapContextLocations: Record<string, Location> = {};
 

--- a/src/request/trips-request/trips-request-params.ts
+++ b/src/request/trips-request/trips-request-params.ts
@@ -20,7 +20,7 @@ export class TripsRequestParams {
     this.transportMode = 'public_transport'
 
     this.includeLegProjection = true
-    this.useNumberOfResultsAfter = false
+    this.useNumberOfResultsAfter = true
   }
 
   public static initWithLocationsAndDate(

--- a/src/request/trips-request/trips-request.ts
+++ b/src/request/trips-request/trips-request.ts
@@ -16,7 +16,9 @@ export class TripRequest extends OJPBaseRequest {
 
   public fetchResponse(completion: (response: TripsResponse, error: RequestErrorData | null) => void) {
     this.buildTripRequestNode();
-    const bodyXML_s = this.serviceRequestNode.end();
+    const bodyXML_s = this.serviceRequestNode.end({
+      pretty: true
+    });
     super.fetchOJPResponse(bodyXML_s, (responseText, errorData) => {
       const tripsResponse = TripsResponse.initWithXML(responseText, this.requestParams.modeType, this.requestParams.transportMode);
       if (errorData === null && !tripsResponse.hasValidResponse) {


### PR DESCRIPTION
- pretty print the XML payload in the OJP APIs calls
- `NumberOfResultsAfter` is now default in the `OJP.TripRequest` calls
- use `PrivateModeFilter` for the OJP APIs calls
- add helpers for reuse of the `OJP.StopEventRequest` calls