### PR TITLE
Support for node v20.x in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.9.22 - 11.12.2023
+- adds support for node v20 in [examples](./examples/)
+
 ## 0.9.21 - 11.12.2023
 - cleanup left-overs
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The OJP Javascript SDK is the client used for communication with [OJP APIs](http
 
 ```
   "dependencies": {
-    "ojp-sdk": "0.9.21"
+    "ojp-sdk": "0.9.22"
   }
 ```
 

--- a/examples/departures-cli/README.md
+++ b/examples/departures-cli/README.md
@@ -19,5 +19,9 @@ const request = OJP.StopEventRequest.initWithStopPlaceRef(OJP.DEFAULT_STAGE, sto
 ```
 - run the main script in the terminal
 ```
+# node 18.x
 $ node --es-module-specifier-resolution=node src/index.js 8500090
+
+# node 20.x
+$ node --import=specifier-resolution-node/register src/index.js 8500090
 ```

--- a/examples/departures-cli/package.json
+++ b/examples/departures-cli/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ojp-sdk": "0.9.11",
+    "ojp-sdk": "0.9.21",
     "specifier-resolution-node": "1.1.1"
   },
   "type": "module"

--- a/examples/departures-cli/package.json
+++ b/examples/departures-cli/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ojp-sdk": "0.9.21",
+    "ojp-sdk": "0.9.22",
     "specifier-resolution-node": "1.1.1"
   },
   "type": "module"

--- a/examples/departures-cli/package.json
+++ b/examples/departures-cli/package.json
@@ -9,7 +9,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "ojp-sdk": "0.9.11"
+    "ojp-sdk": "0.9.11",
+    "specifier-resolution-node": "1.1.1"
   },
   "type": "module"
 }

--- a/examples/departures-webapp/package.json
+++ b/examples/departures-webapp/package.json
@@ -21,7 +21,7 @@
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4",
-    "ojp-sdk": "0.9.21"
+    "ojp-sdk": "0.9.22"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^14.0.6",

--- a/examples/departures-webapp/package.json
+++ b/examples/departures-webapp/package.json
@@ -21,7 +21,7 @@
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4",
-    "ojp-sdk": "0.9.11"
+    "ojp-sdk": "0.9.21"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^14.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ojp-sdk",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "description": "OJP (Open Journey Planner) Javascript SDK",
   "main": "lib/index.js",
   "type": "module",


### PR DESCRIPTION
- Support for node v20.x in examples
- new version `0.9.22`