### PR TITLE
adds abort signal to request

### DIFF
--- a/src/request/base-request.ts
+++ b/src/request/base-request.ts
@@ -17,12 +17,15 @@ export class OJPBaseRequest {
 
   protected logRequests: boolean
 
+  public abortSignal: AbortSignal | null
+
   public lastRequestData: RequestData | null
 
   constructor(stageConfig: StageConfig) {
     this.stageConfig = stageConfig
     this.serviceRequestNode = this.computeServiceRequestNode();
     this.logRequests = false
+    this.abortSignal = null
 
     this.lastRequestData = {
       requestXmlS: null,
@@ -60,6 +63,7 @@ export class OJPBaseRequest {
     const responsePromise = fetch(apiEndpoint, {
       headers: requestHeaders,
       body: bodyXML_s,
+      signal: this.abortSignal,
       method: 'POST'
     });
 

--- a/src/request/journey-request/journey-request.ts
+++ b/src/request/journey-request/journey-request.ts
@@ -43,6 +43,7 @@ export class JourneyRequest extends OJPBaseRequest {
     tripRequestParams.transportMode = this.requestParams.transportModes[idx];
 
     const tripRequest = new TripRequest(this.stageConfig, tripRequestParams);
+    tripRequest.abortSignal = this.abortSignal;
     tripRequest.fetchResponse((tripsResponse, error) => {
       if (error) {
         completion([], error)


### PR DESCRIPTION
It would be nice, if the requests would take abort signals to abort, if it is no longer needed. With this we could wrap the  SDK fetch calls nicely inside obeservables (i.e.)
```ts

const request = new JourneyRequest(STAGE_CONFIG, requestParams);
return new Observable<Trip[]>(subscriber => {
  const aborter = new AbortController();
  request.abortSignal = aborter.signal;
  request.fetchResponse((response, error) => {
    if (error) {
      subscriber.error(error);
    } else {
      subscriber.next(response);
    }
    subscriber.complete();
  });

  return () => aborter.abort();
});
```

This PR is probably not the nicest way to implement this, maybe you have a suggestion on how it could be done @vasile 