### PR TITLE
Fix trip instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 0.9.23 - 09.01.2024
-- add support to compute the trip distance from the individual legs
+- add support to compute the trip distance from the individual legs - [PR #40](https://github.com/openTdataCH/ojp-js/pull/40)
 
 ## 0.9.22 - 11.12.2023
 - adds support for node v20 in [examples](./examples/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.9.23 - 09.01.2024
+- add support to compute the trip distance from the individual legs
+
 ## 0.9.22 - 11.12.2023
 - adds support for node v20 in [examples](./examples/)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The OJP Javascript SDK is the client used for communication with [OJP APIs](http
 
 ```
   "dependencies": {
-    "ojp-sdk": "0.9.22"
+    "ojp-sdk": "0.9.23"
   }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ojp-sdk",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "description": "OJP (Open Journey Planner) Javascript SDK",
   "main": "lib/index.js",
   "type": "module",


### PR DESCRIPTION
The `Trip` cant be instantiated if `ojpTrip/ojp:Distance` is not present, this is an optional node. 
For GUI displaying purposes this PR is fixing by trying to use the the individual legs distances to compute the total distance