### PR TITLE
Support for car-shuttle-train (Autoverladezug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.9.xx - xx.05.2024
 - **BREAKING CHANGE**: change restriction type in `LocationInformationRequest`: update types and use an array for restriction types (i.e. [`stop`, `address`]) - [PR #73](https://github.com/openTdataCH/ojp-js/pull/73)
 - adds `GeoRestriction/Circle` to LIR - [PR #74](https://github.com/openTdataCH/ojp-js/pull/74)
+- adds support for car-shuttle-train (Autoverladezug) - [PR #75](https://github.com/openTdataCH/ojp-js/pull/75)
 - improve `Location/Address` - [PR #71](https://github.com/openTdataCH/ojp-js/pull/71)
 - improve requests: allow LIR requests to use mocked XMLs, adds generic `XMLParser`, adds center min, max long/lat members for GeoPositionBBOX - [PR #72](https://github.com/openTdataCH/ojp-js/pull/72)
 

--- a/src/types/individual-mode.types.ts
+++ b/src/types/individual-mode.types.ts
@@ -1,3 +1,3 @@
 type DefaultIndividualTransportMode = 'public_transport' | 'walk' | 'cycle'
 type SharedIndividualTransportMode = 'escooter_rental' | 'car_sharing' | 'self-drive-car' | 'bicycle_rental'
-export type IndividualTransportMode = DefaultIndividualTransportMode | SharedIndividualTransportMode | 'charging_station' | 'taxi' | 'others-drive-car'
+export type IndividualTransportMode = DefaultIndividualTransportMode | SharedIndividualTransportMode | 'charging_station' | 'taxi' | 'others-drive-car' | 'car-shuttle-train'


### PR DESCRIPTION
- adds new `IndividualTransportMode` type
- detect the leg mode from the `Service` nodes

In the OJP Demo app can be visualized in the following way
![image](https://github.com/openTdataCH/ojp-js/assets/113994/8e64f09d-906d-4141-b657-f50a1caa6684)
