### PR TITLE
resolve circular dependency

### DIFF
--- a/lib/constants.d.ts
+++ b/lib/constants.d.ts
@@ -1,0 +1,2 @@
+export declare const SDK_VERSION = "0.9.35";
+export declare const IS_NODE_CLI: string | false;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,2 @@
+export const SDK_VERSION = '0.9.35';
+export const IS_NODE_CLI = typeof process !== 'undefined' && process.versions && process.versions.node;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,3 @@
-export declare const SDK_VERSION = "0.9.35";
-export declare const IS_NODE_CLI: string | false;
 export * from './config/map-colors';
 export * from './fare/fare';
 export * from './helpers/date-helpers';

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,3 @@
-export const SDK_VERSION = '0.9.35';
-export const IS_NODE_CLI = typeof process !== 'undefined' && process.versions && process.versions.node;
 export * from './config/map-colors';
 export * from './fare/fare';
 export * from './helpers/date-helpers';

--- a/lib/request/base-parser.js
+++ b/lib/request/base-parser.js
@@ -1,6 +1,6 @@
 import * as sax from 'sax';
 import { TreeNode } from "../xml/tree-node";
-import { IS_NODE_CLI } from '..';
+import { IS_NODE_CLI } from '../constants';
 export class BaseParser {
     constructor() {
         this.mapUriNS = {

--- a/lib/request/base-request-params.js
+++ b/lib/request/base-request-params.js
@@ -1,5 +1,5 @@
 import * as xmlbuilder from "xmlbuilder";
-import { SDK_VERSION } from "..";
+import { SDK_VERSION } from "../constants";
 export class BaseRequestParams {
     constructor() {
         this.serviceRequestNode = this.computeBaseServiceRequestNode();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const SDK_VERSION = '0.9.35';
+export const IS_NODE_CLI = typeof process !== 'undefined' && process.versions && process.versions.node;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,3 @@
-export const SDK_VERSION = '0.9.35';
-export const IS_NODE_CLI = typeof process !== 'undefined' && process.versions && process.versions.node;
-
 export * from './config/map-colors'
 
 export * from './fare/fare'

--- a/src/request/base-parser.ts
+++ b/src/request/base-parser.ts
@@ -1,7 +1,7 @@
 import * as sax from 'sax';
 
 import { TreeNode } from "../xml/tree-node";
-import { IS_NODE_CLI } from '..';
+import { IS_NODE_CLI } from '../constants';
 
 export class BaseParser {
   protected rootNode: TreeNode;

--- a/src/request/base-request-params.ts
+++ b/src/request/base-request-params.ts
@@ -1,6 +1,6 @@
 import * as xmlbuilder from "xmlbuilder";
 
-import { SDK_VERSION } from "..";
+import { SDK_VERSION } from "../constants";
 
 export class BaseRequestParams {
   protected serviceRequestNode: xmlbuilder.XMLElement;


### PR DESCRIPTION
We have an error in our deployment caused by a circular dependency.
The error only occurs when some build time optimizations are done by the angular cli / vite.

```
Unhandled error occurred: TypeError: Class extends value undefined is not a constructor or null
    at location-information-request-params.js:3:55
```

The circular path is `LocationInformationRequestParams -> BaseRequestParams -> index -> LocationInformationRequest -> LocationInformationRequestParams`

It can be resolved by removing the two constants from the `index.ts`.