### PR TITLE
Customize NumberOfResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 0.12.3 - 17.09.2024
+- Customize `NumberOfResults` - [PR #108](https://github.com/openTdataCH/ojp-js/pull/108) 
 - Remove `ModeAndModeOfOperationFilter/siri:WaterSubmode` which is for OJP2 - [PR #106](https://github.com/openTdataCH/ojp-js/pull/106) 
 
 ## 0.12.2 - 17.09.2024

--- a/src/request/trips-request/trips-request-params.ts
+++ b/src/request/trips-request/trips-request-params.ts
@@ -297,10 +297,7 @@ export class TripsRequestParams extends BaseRequestParams {
     }
 
     paramsNode.ele("IncludeTrackSections", true);
-    paramsNode.ele(
-      "IncludeLegProjection",
-      this.includeLegProjection
-    );
+    paramsNode.ele("IncludeLegProjection", this.includeLegProjection);
     paramsNode.ele("IncludeTurnDescription", true);
     paramsNode.ele("IncludeIntermediateStops", true);
 

--- a/src/request/trips-request/trips-request-params.ts
+++ b/src/request/trips-request/trips-request-params.ts
@@ -299,7 +299,11 @@ export class TripsRequestParams extends BaseRequestParams {
     paramsNode.ele("IncludeTrackSections", true);
     paramsNode.ele("IncludeLegProjection", this.includeLegProjection);
     paramsNode.ele("IncludeTurnDescription", true);
-    paramsNode.ele("IncludeIntermediateStops", true);
+
+    const isPublicTransport = this.transportMode === 'public_transport';
+    if (isPublicTransport) {
+      paramsNode.ele("IncludeIntermediateStops", true);
+    }
 
     if (isMonomodal) {
       const standardModes: IndividualTransportMode[] = [

--- a/src/request/trips-request/trips-request-params.ts
+++ b/src/request/trips-request/trips-request-params.ts
@@ -14,6 +14,7 @@ export class TripsRequestParams extends BaseRequestParams {
   public departureDate: Date;
   public tripRequestBoardingType: TripRequestBoardingType
   public numberOfResultsType: NumberOfResultsType
+  public numberOfResults: number | null
   
   public modeType: TripModeType;
   public transportMode: IndividualTransportMode;
@@ -28,6 +29,7 @@ export class TripsRequestParams extends BaseRequestParams {
     departureDate: Date = new Date(),
     tripRequestBoardingType: TripRequestBoardingType = 'Dep',
     numberOfResultsType: NumberOfResultsType = 'NumberOfResults',
+    numberOfResults: number | null = null,
   ) {
     super(language);
 
@@ -36,6 +38,7 @@ export class TripsRequestParams extends BaseRequestParams {
     this.departureDate = departureDate;
     this.tripRequestBoardingType = tripRequestBoardingType;
     this.numberOfResultsType = numberOfResultsType;
+    this.numberOfResults = numberOfResults;
 
     this.modeType = "monomodal";
     this.transportMode = "public_transport";
@@ -69,6 +72,7 @@ export class TripsRequestParams extends BaseRequestParams {
     modeType: TripModeType = 'monomodal',
     transportMode: IndividualTransportMode  = 'public_transport',
     viaTripLocations: TripLocationPoint[] = [],
+    numberOfResults: number | null = null,
   ): TripsRequestParams | null {
     if (fromLocation === null || toLocation === null) {
       return null;
@@ -88,6 +92,7 @@ export class TripsRequestParams extends BaseRequestParams {
       modeType,
       transportMode,
       viaTripLocations,
+      numberOfResults,
     );
     return requestParams;
   }
@@ -103,6 +108,7 @@ export class TripsRequestParams extends BaseRequestParams {
     modeType: TripModeType = 'monomodal',
     transportMode: IndividualTransportMode  = 'public_transport',
     viaTripLocations: TripLocationPoint[] = [],
+    numberOfResults: number | null = null,
   ): TripsRequestParams | null {
     if (fromTripLocationPoint === null || toTripLocationPoint === null) {
       return null;
@@ -127,6 +133,7 @@ export class TripsRequestParams extends BaseRequestParams {
       departureDate,
       tripRequestBoardingType,
       numberOfResultsType,
+      numberOfResults,
     );
 
     tripRequestParams.includeLegProjection = includeLegProjection;
@@ -284,9 +291,10 @@ export class TripsRequestParams extends BaseRequestParams {
 
     const paramsNode = tripRequestNode.ele("Params");
 
-    const numberOfResults = 5;
-    const nodeName = this.numberOfResultsType;
-    paramsNode.ele(nodeName, numberOfResults);
+    if (this.numberOfResults !== null) {
+      const nodeName = this.numberOfResultsType;
+      paramsNode.ele(nodeName, this.numberOfResults);
+    }
 
     paramsNode.ele("IncludeTrackSections", true);
     paramsNode.ele(

--- a/src/request/trips-request/trips-request-params.ts
+++ b/src/request/trips-request/trips-request-params.ts
@@ -65,6 +65,10 @@ export class TripsRequestParams extends BaseRequestParams {
     departureDate: Date = new Date(),
     tripRequestBoardingType: TripRequestBoardingType = 'Dep',
     numberOfResultsType: NumberOfResultsType = 'NumberOfResults',
+    includeLegProjection: boolean = false,
+    modeType: TripModeType = 'monomodal',
+    transportMode: IndividualTransportMode  = 'public_transport',
+    viaTripLocations: TripLocationPoint[] = [],
   ): TripsRequestParams | null {
     if (fromLocation === null || toLocation === null) {
       return null;
@@ -80,6 +84,10 @@ export class TripsRequestParams extends BaseRequestParams {
       departureDate, 
       tripRequestBoardingType,
       numberOfResultsType,
+      includeLegProjection,
+      modeType,
+      transportMode,
+      viaTripLocations,
     );
     return requestParams;
   }
@@ -94,7 +102,7 @@ export class TripsRequestParams extends BaseRequestParams {
     includeLegProjection: boolean = false,
     modeType: TripModeType = 'monomodal',
     transportMode: IndividualTransportMode  = 'public_transport',
-    viaTripLocations: TripLocationPoint[] = []
+    viaTripLocations: TripLocationPoint[] = [],
   ): TripsRequestParams | null {
     if (fromTripLocationPoint === null || toTripLocationPoint === null) {
       return null;

--- a/src/request/trips-request/trips-request.ts
+++ b/src/request/trips-request/trips-request.ts
@@ -72,6 +72,7 @@ export class TripRequest extends OJPBaseRequest {
     modeType: TripModeType = 'monomodal',
     transportMode: IndividualTransportMode  = 'public_transport',
     viaTripLocations: TripLocationPoint[] = [],
+    numberOfResults: number | null = null,
   ) {
     const requestParams = TripsRequestParams.initWithTripLocationsAndDate(
       language, 
@@ -84,6 +85,7 @@ export class TripRequest extends OJPBaseRequest {
       modeType,
       transportMode,
       viaTripLocations,
+      numberOfResults,
     );
     if (requestParams === null) {
       return null;


### PR DESCRIPTION
- allow to set the `NumberOfResults` when building TripRequest requests, default is null, in this case will not be sent to OJP backend