### PR TITLE
Refactor NumberOfResults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - adds TripRrequest filter for public transport modes - [Adds mean of transport (bus, boat, etc.) option in the TR #170](https://github.com/openTdataCH/ojp-demo-app-src/issues/170) - [PR #119](https://github.com/openTdataCH/ojp-js/pull/119)
   - BREAKING CHANGE - extract client specific code from SDK
 - refactor `NumberOfResults` - [PR #121](https://github.com/openTdataCH/ojp-js/pull/121)
+  - BREAKING CHANGE - allow also to give NumberOfResultsBefore and NumberOfResultsAfter, all optional, this way no need to send the NumberOfResultsType
 
 ## 0.12.7 - 30.10.2024
 - Fix Service real-time info parsing - [PR #117](https://github.com/openTdataCH/ojp-js/pull/117)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.13.1 - 19.11.2024
 - adds TripRrequest filter for public transport modes - [Adds mean of transport (bus, boat, etc.) option in the TR #170](https://github.com/openTdataCH/ojp-demo-app-src/issues/170) - [PR #119](https://github.com/openTdataCH/ojp-js/pull/119)
   - BREAKING CHANGE - extract client specific code from SDK
+- refactor `NumberOfResults` - [PR #121](https://github.com/openTdataCH/ojp-js/pull/121)
 
 ## 0.12.7 - 30.10.2024
 - Fix Service real-time info parsing - [PR #117](https://github.com/openTdataCH/ojp-js/pull/117)

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -5,6 +5,5 @@ export * from './trips-request/trip-request-response'
 export * from './trips-request/trips-request'
 
 export * from './types/request-info.type'
-export { NumberOfResultsType } from './types/trip-request.type'
 
 export * from './xml-parser'

--- a/src/request/trips-request/trips-request-params.ts
+++ b/src/request/trips-request/trips-request-params.ts
@@ -7,7 +7,6 @@ import { BaseRequestParams } from "../base-request-params";
 import { JourneyPointType } from '../../types/journey-points';
 import { Location } from "../../location/location";
 import { TripRequestBoardingType } from './trips-request'
-import { NumberOfResultsType } from "../types/trip-request.type";
 import { Language } from "../../types/language-type";
 import { ModeOfTransportType } from "../../types/mode-of-transport.type";
 
@@ -16,7 +15,6 @@ export class TripsRequestParams extends BaseRequestParams {
   public toTripLocation: TripLocationPoint;
   public departureDate: Date;
   public tripRequestBoardingType: TripRequestBoardingType
-  public numberOfResultsType: NumberOfResultsType
   public numberOfResults: number | null
   public publicTransportModes: ModeOfTransportType[]
   
@@ -26,14 +24,18 @@ export class TripsRequestParams extends BaseRequestParams {
 
   public viaLocations: TripLocationPoint[]
 
+  public numberOfResultsAfter: number | null
+  public numberOfResultsBefore: number | null
+
   constructor(
     language: Language,
     fromTripLocation: TripLocationPoint,
     toTripLocation: TripLocationPoint,
     departureDate: Date = new Date(),
     tripRequestBoardingType: TripRequestBoardingType = 'Dep',
-    numberOfResultsType: NumberOfResultsType = 'NumberOfResults',
     numberOfResults: number | null = null,
+    numberOfResultsBefore: number | null = null,
+    numberOfResultsAfter: number | null = null,
     publicTransportModes: ModeOfTransportType[] = [],
   ) {
     super(language);
@@ -42,8 +44,11 @@ export class TripsRequestParams extends BaseRequestParams {
     this.toTripLocation = toTripLocation;
     this.departureDate = departureDate;
     this.tripRequestBoardingType = tripRequestBoardingType;
-    this.numberOfResultsType = numberOfResultsType;
+    
     this.numberOfResults = numberOfResults;
+    this.numberOfResultsBefore = numberOfResultsBefore;
+    this.numberOfResultsAfter = numberOfResultsAfter;
+    
     this.publicTransportModes = publicTransportModes;
 
     this.modeType = "monomodal";
@@ -62,7 +67,6 @@ export class TripsRequestParams extends BaseRequestParams {
       emptyTripLocationPoint,
       new Date(),
       'Dep',
-      'NumberOfResults',
     );
     return requestParams;
   }
@@ -73,12 +77,14 @@ export class TripsRequestParams extends BaseRequestParams {
     toLocation: Location | null,
     departureDate: Date = new Date(),
     tripRequestBoardingType: TripRequestBoardingType = 'Dep',
-    numberOfResultsType: NumberOfResultsType = 'NumberOfResults',
     includeLegProjection: boolean = false,
     modeType: TripModeType = 'monomodal',
     transportMode: IndividualTransportMode  = 'public_transport',
     viaTripLocations: TripLocationPoint[] = [],
     numberOfResults: number | null = null,
+    numberOfResultsBefore: number | null = null,
+    numberOfResultsAfter: number | null = null,
+    publicTransportModes: ModeOfTransportType[] = [],
   ): TripsRequestParams | null {
     if (fromLocation === null || toLocation === null) {
       return null;
@@ -93,12 +99,14 @@ export class TripsRequestParams extends BaseRequestParams {
       toTripLocationPoint, 
       departureDate, 
       tripRequestBoardingType,
-      numberOfResultsType,
       includeLegProjection,
       modeType,
       transportMode,
       viaTripLocations,
       numberOfResults,
+      numberOfResultsBefore,
+      numberOfResultsAfter,
+      publicTransportModes,
     );
     return requestParams;
   }
@@ -109,12 +117,13 @@ export class TripsRequestParams extends BaseRequestParams {
     toTripLocationPoint: TripLocationPoint | null,
     departureDate: Date = new Date(),
     tripRequestBoardingType: TripRequestBoardingType = 'Dep',
-    numberOfResultsType: NumberOfResultsType = 'NumberOfResults',
     includeLegProjection: boolean = false,
     modeType: TripModeType = 'monomodal',
     transportMode: IndividualTransportMode  = 'public_transport',
     viaTripLocations: TripLocationPoint[] = [],
     numberOfResults: number | null = null,
+    numberOfResultsBefore: number | null = null,
+    numberOfResultsAfter: number | null = null,
     publicTransportModes: ModeOfTransportType[] = [],
   ): TripsRequestParams | null {
     if (fromTripLocationPoint === null || toTripLocationPoint === null) {
@@ -139,8 +148,9 @@ export class TripsRequestParams extends BaseRequestParams {
       toTripLocationPoint,
       departureDate,
       tripRequestBoardingType,
-      numberOfResultsType,
       numberOfResults,
+      numberOfResultsBefore,
+      numberOfResultsAfter,
       publicTransportModes,
     );
 
@@ -250,8 +260,13 @@ export class TripsRequestParams extends BaseRequestParams {
     }
 
     if (this.numberOfResults !== null) {
-      const nodeName = this.numberOfResultsType;
-      paramsNode.ele(nodeName, this.numberOfResults);
+      paramsNode.ele('NumberOfResults', this.numberOfResults);
+    }
+    if (this.numberOfResultsBefore !== null) {
+      paramsNode.ele('NumberOfResultsBefore', this.numberOfResultsBefore);
+    }
+    if (this.numberOfResultsAfter !== null) {
+      paramsNode.ele('NumberOfResultsAfter', this.numberOfResultsAfter);
     }
 
     paramsNode.ele("IncludeTrackSections", true);

--- a/src/request/trips-request/trips-request.ts
+++ b/src/request/trips-request/trips-request.ts
@@ -1,7 +1,7 @@
 import { OJPBaseRequest } from '../base-request';
 import { TripsRequestParams } from './trips-request-params';
 import { DEFAULT_STAGE, StageConfig } from '../../types/stage-config';
-import { TripRequest_Response, TripRequest_Callback, NumberOfResultsType } from '../types/trip-request.type';
+import { TripRequest_Response, TripRequest_Callback } from '../types/trip-request.type';
 import { TripRequestParser } from './trip-request-parser';
 import { TripLocationPoint } from '../../trip';
 import { Location } from '../../location/location';
@@ -68,12 +68,13 @@ export class TripRequest extends OJPBaseRequest {
     toTripLocation: TripLocationPoint | null, 
     departureDate: Date, 
     tripRequestBoardingType: TripRequestBoardingType = 'Dep', 
-    numberOfResultsType: NumberOfResultsType = 'NumberOfResults', 
     includeLegProjection: boolean = false,
     modeType: TripModeType = 'monomodal',
     transportMode: IndividualTransportMode  = 'public_transport',
     viaTripLocations: TripLocationPoint[] = [],
     numberOfResults: number | null = null,
+    numberOfResultsBefore: number | null = null,
+    numberOfResultsAfter: number | null = null,
     publicTransportModes: ModeOfTransportType[] = [],
   ) {
     const requestParams = TripsRequestParams.initWithTripLocationsAndDate(
@@ -82,12 +83,13 @@ export class TripRequest extends OJPBaseRequest {
       toTripLocation, 
       departureDate, 
       tripRequestBoardingType,
-      numberOfResultsType,
       includeLegProjection,
       modeType,
       transportMode,
       viaTripLocations,
       numberOfResults,
+      numberOfResultsBefore,
+      numberOfResultsAfter,
       publicTransportModes,
     );
     if (requestParams === null) {

--- a/src/request/types/trip-request.type.ts
+++ b/src/request/types/trip-request.type.ts
@@ -1,7 +1,5 @@
 import { Trip } from "../../trip";
 
-export type NumberOfResultsType = 'NumberOfResults' | 'NumberOfResultsBefore' | 'NumberOfResultsAfter'
-
 export type TripRequest_ParserMessage = 'TripRequest.TripsNo' | 'TripRequest.Trip' | 'TripRequest.DONE' | 'ERROR';
 export type TripRequest_Response = {
     tripsNo: number


### PR DESCRIPTION
- **BREAKING CHANGE** - allow also to give `NumberOfResultsBefore` and `NumberOfResultsAfter`, all optional. 
- no more need to maintain one custom type, TripRequest can have both `NumberOfResultsBefore`, `NumberOfResultsAfter` present