### PR TITLE
Change v1 package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 0.17.1 - 2.04.2025
-- changed package name to `ojp-sdk-v1` 
+- changed package name to `ojp-sdk-v1` - [PR #141](https://github.com/openTdataCH/ojp-js/pull/141)
   - prepare to extract the OJP v1.0 SDK code into a separate repo
 
 ## 0.16.3 - 24.03.2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.17.1 - 2.04.2025
+- changed package name to `ojp-sdk-v1` 
+  - prepare to extract the OJP v1.0 SDK code into a separate repo
+
 ## 0.16.3 - 24.03.2025
 - internal change, refactor params/request implementation - [PR #137](https://github.com/openTdataCH/ojp-js/pull/137)
 - adds hack for OJP-SI to allow Trip nodes without Transfer children node - [PR #138](https://github.com/openTdataCH/ojp-js/pull/138)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See [Reference](./docs/reference.md) and [examples](./examples/) for usage.
 
 - OJP Demo App: https://opentdatach.github.io/ojp-demo-app/ - web application this SDK
 - [CHANGELOG](./CHANGELOG.md) for latest changes
-- npm `ojp-sdk` package: https://www.npmjs.com/package/ojp-sdk
+- npm `ojp-sdk-v1` package: https://www.npmjs.com/package/ojp-sdk-v1
 
 ## Install
 
@@ -21,7 +21,7 @@ Two versions of the OJP APIs can be used:
 - [OJP 2.0](https://opentransportdata.swiss/de/cookbook/ojp2entwicklung/) - next version, see [VDVde/OJP](https://github.com/VDVde/OJP/blob/changes_for_v1.1/README.md) specs
 
 ### OJP 1.0
-The  main branch of this repo is using OJP 1.0 APIs. The releases are published to [npmjs.com](https://www.npmjs.com/package/ojp-sdk) as `ojp-sdk-v1` package. 
+The  main branch of this repo is using OJP 1.0 APIs. The releases are published to [npmjs.com](https://www.npmjs.com/package/ojp-sdk-v1) as `ojp-sdk-v1` package. 
 
 
 - include the `ojp-sdk-v1` package in the `./package.json` dependencies of your project 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # OJP Javascript SDK
 
-**Note 2.Apr 2025**: OJP v1.0 will be discontinued and this repo will be cloned into another project. [ojp-sdk-next](https://github.com/openTdataCH/ojp-js/tree/feature/ojp-sdk-next) branch based on OJP v2.0 will replace this branch.
+**Note 2.Apr 2025**: The main branch of this repo is freezed for development.
+
+- for [OJP v1.0](https://opentransportdata.swiss/en/cookbook/open-journey-planner-ojp/) - check [feature/ojp-v1](https://github.com/openTdataCH/ojp-js/tree/feature/ojp-v1) branch. Features for this branch will receive less support in the future
+- for [OJP v2.0](https://opentransportdata.swiss/en/cookbook/open-journey-planner-ojp/) - check [feature/ojp-sdk-next](https://github.com/openTdataCH/ojp-js/tree/feature/ojp-sdk-next) branch. **OJP v2.0 branch has full support in development and will replace the main branch of this repo**
 
 ----
 
@@ -12,28 +15,16 @@ See [Reference](./docs/reference.md) and [examples](./examples/) for usage.
 
 - OJP Demo App: https://opentdatach.github.io/ojp-demo-app/ - web application this SDK
 - [CHANGELOG](./CHANGELOG.md) for latest changes
-- npm `ojp-sdk-v1` package: https://www.npmjs.com/package/ojp-sdk-v1
+- npm `ojp-sdk` package: https://www.npmjs.com/package/ojp-sdk
 
 ## Install
 
-Two versions of the OJP APIs can be used:
-- [OJP 1.0](https://opentransportdata.swiss/en/cookbook/open-journey-planner-ojp/) - still supported by `ojp-js` SDK but might receive less support in the future
-- [OJP 2.0](https://opentransportdata.swiss/de/cookbook/ojp2entwicklung/) - next version, see [VDVde/OJP](https://github.com/VDVde/OJP/blob/changes_for_v1.1/README.md) specs
-
-### OJP 1.0
-The  main branch of this repo is using OJP 1.0 APIs. The releases are published to [npmjs.com](https://www.npmjs.com/package/ojp-sdk-v1) as `ojp-sdk-v1` package. 
-
-
-- include the `ojp-sdk-v1` package in the `./package.json` dependencies of your project 
+- include the `ojp-sdk` package in the `./package.json` dependencies of your project 
 ```
   "dependencies": {
-    "ojp-sdk-v1": "0.17.1"
+    "ojp-sdk": "0.20.2"
   }
 ```
-
-### OJP 2.0
-
-see [ojp-sdk-next](https://github.com/openTdataCH/ojp-js/tree/feature/ojp-sdk-next) branch
 
 ## Usage
 
@@ -44,7 +35,7 @@ $ npm install
 
 - include OJP SDK in the Typescript / Javascript code
 ```
-import * as OJP from 'ojp-sdk-v1'
+import * as OJP from 'ojp-sdk'
 ```
 
 - for more details check:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # OJP Javascript SDK
 
+**Note 2.Apr 2025**: OJP v1.0 will be discontinued and this repo will be cloned into another project. [ojp-sdk-next](https://github.com/openTdataCH/ojp-js/tree/feature/ojp-sdk-next) branch based on OJP v2.0 will replace this branch.
+
+----
+
 The OJP Javascript SDK is a Javascript/Typescript package used for communication with [OJP APIs](https://opentransportdata.swiss/en/cookbook/open-journey-planner-ojp/).
 
 See [Reference](./docs/reference.md) and [examples](./examples/) for usage.
@@ -17,23 +21,19 @@ Two versions of the OJP APIs can be used:
 - [OJP 2.0](https://opentransportdata.swiss/de/cookbook/ojp2entwicklung/) - next version, see [VDVde/OJP](https://github.com/VDVde/OJP/blob/changes_for_v1.1/README.md) specs
 
 ### OJP 1.0
-The  main branch of `ojp-js` repo is using OJP 1.0 APIs. The releases are published to [npmjs.com](https://www.npmjs.com/package/ojp-sdk) as `ojp-sdk` packages. 
+The  main branch of this repo is using OJP 1.0 APIs. The releases are published to [npmjs.com](https://www.npmjs.com/package/ojp-sdk) as `ojp-sdk-v1` package. 
 
-- include the `ojp-sdk` package in the `./package.json` dependencies of your project 
+
+- include the `ojp-sdk-v1` package in the `./package.json` dependencies of your project 
 ```
   "dependencies": {
-    "ojp-sdk": "0.16.3"
+    "ojp-sdk-v1": "0.17.1"
   }
 ```
 
 ### OJP 2.0
-The [ojp-v2](https://github.com/openTdataCH/ojp-js/tree/feature/ojp-v2) branch is used for developing [OJP 2.0](https://opentransportdata.swiss/de/cookbook/ojp2entwicklung/) bindings, 
-- include the `#ojp-v2` branch
-```
-  "dependencies": {
-    "ojp-sdk": "git+https://github.com/openTdataCH/ojp-js.git#feature/ojp-v2"
-  }
-```
+
+see [ojp-sdk-next](https://github.com/openTdataCH/ojp-js/tree/feature/ojp-sdk-next) branch
 
 ## Usage
 
@@ -44,7 +44,7 @@ $ npm install
 
 - include OJP SDK in the Typescript / Javascript code
 ```
-import * as OJP from 'ojp-sdk'
+import * as OJP from 'ojp-sdk-v1'
 ```
 
 - for more details check:
@@ -56,4 +56,4 @@ import * as OJP from 'ojp-sdk'
 
 The project is released under a [MIT license](./LICENSE).
 
-Copyright (c) 2021 - 2024 Open Data Platform Mobility Switzerland - [opentransportdata.swiss](https://opentransportdata.swiss/en/).
+Copyright (c) 2021 - 2025 Open Data Platform Mobility Switzerland - [opentransportdata.swiss](https://opentransportdata.swiss/en/).

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ojp-sdk",
+  "name": "ojp-sdk-v1",
   "version": "0.17.1",
   "description": "OJP (Open Journey Planner) Javascript SDK",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ojp-sdk",
-  "version": "0.16.3",
+  "version": "0.17.1",
   "description": "OJP (Open Journey Planner) Javascript SDK",
   "main": "lib/index.js",
   "type": "module",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,7 @@ export const DEBUG_LEVEL: DEBUG_LEVEL_Type = (() => {
 
 type OJP_VERSION_Type = '1.0' | '2.0';
 export const OJP_VERSION: OJP_VERSION_Type = '1.0';
-export const SDK_VERSION = '0.16.3';
+export const SDK_VERSION = '0.17.1';
 export const IS_NODE_CLI = typeof process !== 'undefined' && process.versions && process.versions.node;
 
 if (DEBUG_LEVEL === 'DEBUG') {


### PR DESCRIPTION
- changes package name to `ojp-sdk-v1` 
- updates README
  - discontinued OJP v1.0 - prepare for a new branch
  - stated that OJP v2.0 branch will receive full support / replace main branch